### PR TITLE
Fixes ability to use Cloudformation intrinsic functions to specify SNS event sources

### DIFF
--- a/docs/providers/aws/events/sns.md
+++ b/docs/providers/aws/events/sns.md
@@ -69,16 +69,15 @@ functions:
       - sns:
           arn:
             Fn::Join:
-              - ""
-              - - "arn:aws:sns:"
+              - ":"
+              - - "arn:aws:sns"
                 - Ref: "AWS::Region"
-                - ":"
                 - Ref: "AWS::AccountId"
-                - ":MyCustomTopic"
+                - "MyCustomTopic"
           topicName: MyCustomTopic
 ```
 
-**Note:** It is important to know that `topicArn` must contain the value given in the `topicName` property.
+**Note:** If an `arn` string is specified but not a `topicName`, the last substring starting with `:` will be extracted as the `topicName`. If an `arn` object is specified, `topicName` must be specified as a string, used only to name the underlying Cloudformation mapping resources.
 
 ## Setting a display name
 

--- a/lib/plugins/aws/package/compile/events/sns/index.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.js
@@ -12,6 +12,30 @@ class AwsCompileSNSEvents {
     };
   }
 
+  invalidPropertyErrorMessage(functionName, property) {
+    return [
+      `Missing or invalid ${property} property for sns event`,
+      ` in function "${functionName}"`,
+      ' The correct syntax is: sns: topic-name-or-arn',
+      ' OR an object with ',
+      ' arn and topicName OR',
+      ' topicName and displayName.',
+      ' Please check the docs for more info.',
+    ].join('');
+  }
+
+  isValidStackImport(variable) {
+    if (Object.keys(variable).length !== 1) {
+      return false;
+    }
+    if (_.has(variable, 'Fn::ImportValue') &&
+      (_.has(variable, 'Fn::ImportValue.Fn::GetAtt') || _.has(variable, 'Fn::ImportValue.Ref'))) {
+      return false;
+    }
+    const intrinsicFunctions = ['Fn::ImportValue', 'Ref', 'Fn::GetAtt', 'Fn::Sub', 'Fn::Join'];
+    return !!_.find(intrinsicFunctions, func => _.has(variable, func));
+  }
+
   compileSNSEvents() {
     const template = this.serverless.service.provider.compiledCloudFormationTemplate;
 
@@ -27,45 +51,23 @@ class AwsCompileSNSEvents {
 
             if (typeof event.sns === 'object') {
               if (event.sns.arn) {
-                if (typeof event.sns.arn === 'object' ||
-                  typeof event.sns.arn === 'string') {
-                  if (event.sns.topicName && typeof event.sns.topicName === 'string') {
-                    topicArn = event.sns.arn;
-                    topicName = event.sns.topicName;
-                  } else if (event.sns.arn.indexOf('arn:') === 0) {
-                    topicArn = event.sns.arn;
+                topicArn = event.sns.arn;
+                if (typeof topicArn === 'object') {
+                  if (!this.isValidStackImport(topicArn)) {
+                    throw new this.serverless.classes
+                      .Error(this.invalidPropertyErrorMessage(functionName, 'arn'));
+                  }
+                } else if (typeof topicArn === 'string') {
+                  if (topicArn.indexOf('arn:') === 0) {
                     const splitArn = topicArn.split(':');
                     topicName = splitArn[splitArn.length - 1];
                   } else {
-                    const errorMessage = [
-                      'Missing or invalid topicName property for sns event',
-                      ` in function "${functionName}"`,
-                      ' The correct syntax is: sns: topic-name-or-arn',
-                      ' OR an object with ',
-                      ' arn and topicName OR',
-                      ' topicName and displayName.',
-                      ' Please check the docs for more info.',
-                    ].join('');
                     throw new this.serverless.classes
-                      .Error(errorMessage);
+                      .Error(this.invalidPropertyErrorMessage(functionName, 'arn'));
                   }
                 } else {
                   const errorMessage = [
-                    'Invalid value type provided .arn property for sns event',
-                    ` in function ${functionName}`,
-                    ' The correct types are: object, string.',
-                    ' Please check the docs for more info.',
-                  ].join('');
-                  throw new this.serverless.classes
-                    .Error(errorMessage);
-                }
-              } else {
-                ['topicName', 'displayName'].forEach((property) => {
-                  if (typeof event.sns[property] === 'string') {
-                    return;
-                  }
-                  const errorMessage = [
-                    'Missing or invalid topicName property for sns event',
+                    `Invalid ARN property for sns event`,
                     ` in function "${functionName}"`,
                     ' The correct syntax is: sns: topic-name-or-arn',
                     ' OR an object with ',
@@ -75,6 +77,19 @@ class AwsCompileSNSEvents {
                   ].join('');
                   throw new this.serverless.classes
                     .Error(errorMessage);
+                }
+                topicName = topicName || event.sns.topicName;
+                if (!topicName || typeof topicName !== 'string') {
+                  throw new this.serverless.classes
+                    .Error(this.invalidPropertyErrorMessage(functionName, 'topicName'));
+                }
+              } else {
+                ['topicName', 'displayName'].forEach((property) => {
+                  if (typeof event.sns[property] === 'string') {
+                    return;
+                  }
+                  throw new this.serverless.classes
+                    .Error(this.invalidPropertyErrorMessage(functionName, property));
                 });
                 displayName = event.sns.displayName;
                 topicName = event.sns.topicName;
@@ -91,7 +106,9 @@ class AwsCompileSNSEvents {
               const errorMessage = [
                 `SNS event of function ${functionName} is not an object nor a string`,
                 ' The correct syntax is: sns: topic-name-or-arn',
-                ' OR an object with "topicName" AND "displayName" properties.',
+                ' OR an object with ',
+                ' arn and topicName OR',
+                ' topicName and displayName.',
                 ' Please check the docs for more info.',
               ].join('');
               throw new this.serverless.classes

--- a/lib/plugins/aws/package/compile/events/sns/index.test.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.test.js
@@ -291,6 +291,115 @@ describe('AwsCompileSNSEvents', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
 
+    // eslint-disable-next-line max-len
+    it('should create SNS topic when arn object and topicName are given as object properties', () => {
+      awsCompileSNSEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              sns: {
+                topicName: 'bar',
+                arn: {
+                  'Fn::Join': [
+                    ':',
+                    [
+                      'arn:aws:sns',
+                      '${AWS::Region}',
+                      '${AWS::AccountId}',
+                      'bar',
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileSNSEvents.compileSNSEvents();
+
+      expect(Object.keys(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources)
+      ).to.have.length(2);
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstSnsSubscriptionBar.Type
+      ).to.equal('AWS::SNS::Subscription');
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstLambdaPermissionBarSNS.Type
+      ).to.equal('AWS::Lambda::Permission');
+    });
+
+    // eslint-disable-next-line max-len
+    it('should throw an error when arn object and no topicName are given as object properties', () => {
+      awsCompileSNSEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              sns: {
+                arn: {
+                  'Fn::Join': [
+                    ':',
+                    [
+                      'arn:aws:sns',
+                      '${AWS::Region}',
+                      '${AWS::AccountId}',
+                      'bar',
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => { awsCompileSNSEvents.compileSNSEvents(); }).to.throw(Error);
+    });
+
+    // eslint-disable-next-line max-len
+    it('should throw an error when invalid imported arn object is given as object properties', () => {
+      awsCompileSNSEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              sns: {
+                topicName: 'bar',
+                arn: {
+                  'Fn::ImportValue': {
+                    Ref: 'BarTopic',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => { awsCompileSNSEvents.compileSNSEvents(); }).to.throw(Error);
+
+      awsCompileSNSEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              sns: {
+                topicName: 'bar',
+                arn: {
+                  'Fn::ImportValue': {
+                    'Fn::GetAtt': [
+                      'BarTopic',
+                      'Arn',
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => { awsCompileSNSEvents.compileSNSEvents(); }).to.throw(Error);
+    });
+
     it('should create SNS topic when arn, topicName, and filterPolicy are given as object', () => {
       awsCompileSNSEvents.serverless.service.functions = {
         first: {

--- a/tests/integration/aws/sns/existing-topic/service/serverless.yml
+++ b/tests/integration/aws/sns/existing-topic/service/serverless.yml
@@ -8,4 +8,13 @@ functions:
   hello:
     handler: handler.hello
     events:
-      - sns: ${env:EXISTING_TOPIC_ARN}
+      - sns:
+          arn:
+            Fn::Join:
+              - ':'
+              -
+                - 'arn:aws:sns'
+                - ${env:EXISTING_TOPIC_REGION}
+                - ${env:EXISTING_TOPIC_ACCOUNT}
+                - ${env:EXISTING_TOPIC_NAME}
+          topicName: ${env:EXISTING_TOPIC_NAME}

--- a/tests/integration/aws/sns/existing-topic/tests.js
+++ b/tests/integration/aws/sns/existing-topic/tests.js
@@ -10,7 +10,10 @@ describe('AWS - SNS: Existing topic with single function', () => {
 
   beforeAll(() => Utils.createSnsTopic(snsTopic)
     .then((result) => {
-      process.env.EXISTING_TOPIC_ARN = result.TopicArn;
+      const splitTopicArn = result.topicArn.split(':');
+      process.env.EXISTING_TOPIC_REGION = splitTopicArn[3];
+      process.env.EXISTING_TOPIC_ACCOUNT = splitTopicArn[4];
+      process.env.EXISTING_TOPIC_NAME = splitTopicArn[5];
     })
     .then(() => {
       Utils.createTestService('aws-nodejs', path.join(__dirname, 'service'));


### PR DESCRIPTION
It is sometimes necessary to use Cloudformation functions to reference SNS event sources created elsewhere, either within the current or other stacks. This feature was documented as working, but in practice an improper string check was stopping object values of the arn property. Additionally, a check to make sure usages of Fn::ImportValue did not include Fn::GetAtt or Ref was incomplete.

This fixes the logic to be in line with the documented feature, as well as adding a few relevant tests and updating the docs.